### PR TITLE
feat: add Wayland clipboard support with wl-copy fallback

### DIFF
--- a/fzf-url.rb
+++ b/fzf-url.rb
@@ -60,6 +60,7 @@ if selected.first == 'ctrl-y'
   # https://superuser.com/questions/288320/whats-like-osxs-pbcopy-for-linux
   copier = executable('reattach-to-user-namespace pbcopy',
                       'pbcopy',
+                      'wl-copy',
                       'xsel --clipboard --input',
                       'xclip -selection clipboard')
   halt 'No command to control clipboard with' unless copier


### PR DESCRIPTION
Previously, the clipboard integration only supported macOS (pbcopy) and 
X11 tools (xclip, xsel). On pure Wayland sessions, copying text with 
Ctrl-y failed unless X11 compatibility tools were installed. 