### PR TITLE
use sh -c when selecting executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 tmux-fzf-url
 ============
 
-Open URLs in the current pane with fzf.
+Search the current tmux pane for URLs, use fzf to select one, and either
+open it or copy it to the system clipboard.
 
 Prerequisites
 -------------
@@ -22,6 +23,19 @@ Add this line to your tmux config file, then hit `prefix + I`:
 ```sh
 set -g @plugin 'junegunn/tmux-fzf-url'
 ```
+
+### Manually
+
+All you need to do is associate a tmux keybinding to run the Ruby
+script. Add something like this to your `.tmux.conf` configuration file:
+
+```
+bind-key u run -b "/path/to/fzf-url.rb";
+```
+
+If you use [byobu](https://www.byobu.org/), you can put the script in
+your byobu configuration directory and use
+`$BYOBU_CONFIG_DIR/fzf-url.rb`.
 
 Usage
 -----

--- a/fzf-url.rb
+++ b/fzf-url.rb
@@ -42,7 +42,7 @@ urls = lines.each_line.map(&:strip).reject(&:empty?)
             .flat_map { |l| extract_urls(l) }.reverse.uniq
 halt 'No URLs found' if urls.empty?
 
-header = 'Select URL: <enter> to open, <ctrl-Y> to copy to clipboard'
+header = 'Enter: Open URL / CTRL-Y: Copy to clipboard'
 max_size = `tmux display-message -p "\#{client_width} \#{client_height}"`.split.map(&:to_i)
 size = [[*urls, header].map(&:length).max + 2 + 4 + 2, urls.length + 5 + 1 + 1].zip(max_size).map(&:min).join(',')
 opts = ['--tmux', size, '--multi', '--no-margin', '--no-padding', '--wrap',

--- a/fzf-url.rb
+++ b/fzf-url.rb
@@ -6,7 +6,7 @@ require 'shellwords'
 
 def executable(*commands)
   commands.find do |c|
-    `command -v #{c.split.first}`.empty?.!
+    `sh -c 'command -v #{c.split.first}'`.empty?.!
   end
 end
 

--- a/fzf-url.rb
+++ b/fzf-url.rb
@@ -6,7 +6,7 @@ require 'shellwords'
 
 def executable(*commands)
   commands.find do |c|
-    `sh -c 'command -v #{c.split.first}'`.empty?.!
+    `command -v "#{c.split.first}"`.empty?.!
   end
 end
 

--- a/fzf-url.rb
+++ b/fzf-url.rb
@@ -42,7 +42,7 @@ urls = lines.each_line.map(&:strip).reject(&:empty?)
             .flat_map { |l| extract_urls(l) }.reverse.uniq
 halt 'No URLs found' if urls.empty?
 
-header = 'Press CTRL-Y to copy URL to clipboard'
+header = 'Select URL: <enter> to open, <ctrl-Y> to copy to clipboard'
 max_size = `tmux display-message -p "\#{client_width} \#{client_height}"`.split.map(&:to_i)
 size = [[*urls, header].map(&:length).max + 2 + 4 + 2, urls.length + 5 + 1 + 1].zip(max_size).map(&:min).join(',')
 opts = ['--tmux', size, '--multi', '--no-margin', '--no-padding', '--wrap',


### PR DESCRIPTION
Fixes #3: on some systems, the backtick string is executed in some context in which the shell builtin `command` is not available; using `sh -c` ensures that it is.